### PR TITLE
Enhance Workflow Timing Collector to Send Formatted Job and Step Data to New Relic

### DIFF
--- a/.github/scripts/format-jobs.sh
+++ b/.github/scripts/format-jobs.sh
@@ -6,7 +6,7 @@ LATEST_RUN_ID="$2"
 REPO="$3"
 WORKFLOW_NAME="$4"
 
-jq -c '.jobs[] | {
+jq -c '[.jobs[] | {
   repository: "'$REPO'",
   workflow_name: "'$WORKFLOW_NAME'",
   run_id: "'$LATEST_RUN_ID'",
@@ -25,4 +25,4 @@ jq -c '.jobs[] | {
       step_completed_at: .completed_at
     }
   ]
-}' "$INPUT_FILE" > formatted_jobs.json
+}]' "$INPUT_FILE" > formatted_jobs.json

--- a/.github/scripts/format-jobs.sh
+++ b/.github/scripts/format-jobs.sh
@@ -6,7 +6,9 @@ LATEST_RUN_ID="$2"
 REPO="$3"
 WORKFLOW_NAME="$4"
 
-jq -c '[.jobs[] | {
+rm -f formatted_jobs.json
+
+jq -c '[.jobs[] | select(.steps != null) | { 
   repository: "'$REPO'",
   workflow_name: "'$WORKFLOW_NAME'",
   run_id: "'$LATEST_RUN_ID'",
@@ -16,13 +18,20 @@ jq -c '[.jobs[] | {
   job_conclusion: .conclusion,
   job_started_at: .started_at,
   job_completed_at: .completed_at,
-  steps: [
-    .steps[] | {
-      step_name: .name,
-      step_status: .status,
-      step_conclusion: .conclusion,
-      step_started_at: .started_at,
-      step_completed_at: .completed_at
-    }
-  ]
+  steps: .steps
+} as $job | $job.steps[] | {
+  repository: $job.repository,
+  workflow_name: $job.workflow_name,
+  run_id: $job.run_id,
+  job_id: $job.job_id,
+  job_name: $job.job_name,
+  job_status: $job.job_status,
+  job_conclusion: $job.job_conclusion,
+  job_started_at: $job.job_started_at,
+  job_completed_at: $job.job_completed_at,
+  step_name: .name,
+  step_status: .status,
+  step_conclusion: .conclusion,
+  step_started_at: .started_at,
+  step_completed_at: .completed_at
 }]' "$INPUT_FILE" > formatted_jobs.json

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -14,7 +14,7 @@ env:
   NEW_RELIC_INSERT_KEY: ${{ secrets.NEW_RELIC_INSERT_KEY }}
   NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
   REPO: ${{ github.repository }}
-  WORKFLOW_NAME: ${{ github.event.workflow.name }}
+  WORKFLOW_NAME: ci.yml
 
 jobs:
   collect_timings:

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -58,7 +58,7 @@ jobs:
           echo "Finished fetching jobs and steps."
 
       - name: Upload jobs.json Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jobs-json
           path: jobs.json
@@ -75,7 +75,7 @@ jobs:
           echo "Finished formatting jobs and steps."
 
       - name: Upload formatted_jobs.json Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: formatted-jobs-json
           path: formatted_jobs.json

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -85,17 +85,15 @@ jobs:
           set -e
           echo "Starting to send timing data to New Relic..."
 
-          data=$(jq -c '[.[]]' formatted_jobs.json)
-
-          curl -X POST "https://insights-collector.newrelic.com/v1/accounts/${{ secrets.NEW_RELIC_ACCOUNT_ID }}/events" \
-            -H "Content-Type: application/json" \
-            -H "X-Insert-Key: ${{ secrets.NEW_RELIC_INSERT_KEY }}" \
-            -d "[
-                  {
-                    \"eventType\": \"GitHubWorkflowTiming\",
-                    \"timestamp\": $(date +%s),
-                    \"data\": $data
-                  }
-                ]"
+          while IFS= read -r line; do
+            # Each $line is a JSON object for a job
+            event=$(jq -c --argjson obj "$line" \
+              '{eventType: "GitHubWorkflowTiming"} + $obj' <<<"$line")
+            echo "Sending event to New Relic: $event"
+            curl -X POST "https://insights-collector.newrelic.com/v1/accounts/${{ secrets.NEW_RELIC_ACCOUNT_ID }}/events" \
+              -H "Content-Type: application/json" \
+              -H "X-Insert-Key: ${{ secrets.NEW_RELIC_INSERT_KEY }}" \
+              -d "[$event]"
+          done < formatted_jobs.json
 
           echo "Finished sending timing data to New Relic."

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -5,6 +5,12 @@ on:
     workflows: ["Rust CI"] # <-- List the workflows you want to monitor
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      workflow_name:
+        description: 'Workflow name to monitor'
+        required: false
+        default: 'ci.yml'
 
 permissions:
   contents: read
@@ -14,7 +20,7 @@ env:
   NEW_RELIC_INSERT_KEY: ${{ secrets.NEW_RELIC_INSERT_KEY }}
   NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
   REPO: ${{ github.repository }}
-  WORKFLOW_NAME: ci.yml
+  WORKFLOW_NAME: ci.yml # Default workflow name
 
 jobs:
   collect_timings:


### PR DESCRIPTION
This PR updates the monitor.yml workflow to:
	•	Fetch the latest completed workflow run for “Rust CI”
	•	Retrieve all associated jobs and steps
	•	Format the job and step data into a structured formatted_jobs.json file
	•	Upload jobs.json and formatted_jobs.json as artifacts for auditing
	•	Send each job+step record as individual custom events to New Relic
	•	Improve script robustness with fail-fast (set -e) and debug output

These improvements ensure better observability of CI/CD performance inside New Relic and make the system easier to debug and extend.